### PR TITLE
Frontend kann mit und ohne Container gestartet werden

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,8 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "set PORT=4200 && react-scripts start",
+    "start:container": "PORT=4200 react-scripts start",
+    "start:nocontainer": "set PORT=4200 && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/compose.yml
+++ b/compose.yml
@@ -7,7 +7,7 @@ services:
       - ./client:/client
     container_name: client
     working_dir: /client
-    command: sh -c "npm install && npm run start"
+    command: sh -c "npm install && npm run start:container"
     environment:
       - WATCHPACK_POLLING=true
     depends_on:


### PR DESCRIPTION
`npm start:nocontainer` startet Frontend ohne Container
`npm start:container` startet Frontend im Container in `compose.yml` Datei